### PR TITLE
Update showroom theme to rhdp_showroom_theme (main)

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -11,7 +11,7 @@ content:
 
 ui:
   bundle:
-    url: https://github.com/rhpds/nookbag-bundle/releases/download/v0.0.3/ui-bundle.zip
+    url: https://github.com/rhpds/rhdp_showroom_theme/releases/download/v0.0.1/ui-bundle.zip
     snapshot: true
   supplemental_files:
     - path: ./content/supplemental-ui


### PR DESCRIPTION
## Summary
- Switch UI bundle from `nookbag-bundle` v0.0.3 (no sidebar navigation) to `rhdp_showroom_theme` v0.0.1
- Adds standard showroom sidebar navigation layout
- Companion to the version branch PR — this updates `main` for GH Pages

## Test plan
- After merging, trigger `workflow_dispatch` on `main` to redeploy GH Pages